### PR TITLE
Add MySQL connection setup

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,25 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+MYSQL_USER     = os.getenv("MYSQL_USER")
+MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD")
+MYSQL_HOST     = os.getenv("MYSQL_HOST")
+MYSQL_PORT     = os.getenv("MYSQL_PORT")
+MYSQL_DB       = os.getenv("MYSQL_DB")
+
+# Как можно скачать сертификат для подключения к MySQL
+# mkdir ~/.mysql
+# curl -o ~/.mysql/root.crt https://storage.yandexcloud.net/cloud-certs/CA.pem
+ssl_ca_path = os.path.expanduser("~/.mysql/root.crt")
+assert os.path.isfile(ssl_ca_path), "Не найден сертификат для подключения к MySQL"
+
+engine = create_engine(f"mysql://{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_HOST}:{MYSQL_PORT}/{MYSQL_DB}?ssl_ca={ssl_ca_path}", pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+# Разогреваем пул, чтобы не было задержек при первом подключении
+with engine.connect() as connection:
+    pass


### PR DESCRIPTION
## Summary
- add SQLAlchemy-based MySQL connection setup with SSL certificate verification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689772d0b6708329a7401c3df9473014