### PR TITLE
Add initial database schema for users and transcription history

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,24 @@
+-- Schema definition for ClearTranscriptBot
+
+-- Users table holds Telegram users interacting with the bot
+CREATE TABLE IF NOT EXISTS users (
+    telegram_id BIGINT PRIMARY KEY,
+    telegram_login VARCHAR(32),
+    balance DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- History of transcription requests made by users
+CREATE TABLE IF NOT EXISTS transcription_history (
+    id SERIAL PRIMARY KEY,
+    telegram_id BIGINT NOT NULL REFERENCES users(telegram_id),
+    status VARCHAR(32) NOT NULL,
+    audio_s3_path TEXT NOT NULL,
+    duration_seconds INTEGER,
+    result_s3_path TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index to speed up lookups by user
+CREATE INDEX IF NOT EXISTS idx_transcription_history_telegram_id
+    ON transcription_history(telegram_id);


### PR DESCRIPTION
## Summary
- add `schema.sql` defining `users` table with balance and registration timestamp
- add `transcription_history` table storing audio and result paths with status and duration
- create index on transcription history user lookups

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897740b5bd48329906de4b6bd236b49