### PR TITLE
Document database schema and add SQLAlchemy models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # ClearTranscriptBot
+
+## Database schema
+
+The bot uses a small PostgreSQL database for storing users and the transcripts they create.
+
+```sql
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    tg_id INTEGER UNIQUE NOT NULL,
+    name VARCHAR(127),
+    registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE transcripts (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    file_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```

--- a/db.py
+++ b/db.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    # Internal identifier
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Telegram user ID
+    tg_id = Column(Integer, unique=True, nullable=False, index=True)
+
+    # User name from Telegram profile
+    name = Column(String(127), nullable=True)
+
+    # When the user first interacted with the bot
+    registered_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    transcripts = relationship("Transcript", back_populates="user")
+
+
+class Transcript(Base):
+    __tablename__ = "transcripts"
+
+    # Transcript identifier
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # Owner user id
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    # Path to the transcript file
+    file_path = Column(String(255), nullable=False)
+
+    # When the transcript was created
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="transcripts")


### PR DESCRIPTION
## Summary
- document user/transcript tables in README
- add SQLAlchemy models for users and transcripts

## Testing
- `python -m py_compile db.py`
- `pip install sqlalchemy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6897768f50f48329bed57991544fb173