### PR TITLE
Add Telegram bot with scheduled SpeechKit polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS transcription_history (
     audio_s3_path TEXT NOT NULL,
     duration_seconds INTEGER,
     result_s3_path TEXT,
+    operation_id VARCHAR(128),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/database/models.py
+++ b/database/models.py
@@ -63,5 +63,8 @@ class TranscriptionHistory(Base):
     # Path to the transcription result in S3
     result_s3_path = Column(Text, nullable=True)
 
+    # Identifier of Yandex Cloud operation
+    operation_id = Column(String(128), nullable=True)
+
     # Timestamp when the request was created
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())

--- a/database/queries.py
+++ b/database/queries.py
@@ -58,3 +58,13 @@ def update_transcription(transcription_id: int, **fields: Any) -> Optional[Trans
         session.commit()
         session.refresh(history)
         return history
+
+
+def get_transcriptions_by_status(status: str) -> list[TranscriptionHistory]:
+    """Return all transcriptions with the specified *status*."""
+    with SessionLocal() as session:
+        return (
+            session.query(TranscriptionHistory)
+            .filter(TranscriptionHistory.status == status)
+            .all()
+        )

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,27 @@
+"""Periodic scheduler for checking transcription statuses."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from telegram.ext import ContextTypes
+
+from database.queries import get_transcriptions_by_status, update_transcription
+from utils.speechkit import get_transcription
+
+
+async def check_running_tasks(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Poll running transcriptions and send results when ready."""
+    bot = context.bot
+    tasks = get_transcriptions_by_status("running")
+    for item in tasks:
+        result = get_transcription(item.operation_id)
+        if result is None:
+            continue
+        text = "\n".join(c.get("text", "") for c in result.get("chunks", []))
+        path = Path(f"transcription_{item.id}.txt")
+        path.write_text(text, encoding="utf-8")
+        try:
+            await bot.send_document(chat_id=item.telegram_id, document=path.open("rb"))
+        finally:
+            path.unlink(missing_ok=True)
+        update_transcription(item.id, status="completed", result_s3_path=None)


### PR DESCRIPTION
## Summary
- integrate python-telegram-bot into main entrypoint
- add scheduler to poll running Yandex SpeechKit operations
- persist SpeechKit operation ids in database and provide query helpers

## Testing
- `python -m py_compile main.py scheduler.py database/models.py database/queries.py utils/speechkit.py`
- `pytest -q`
- `pip install python-telegram-bot --quiet` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68977f325b7883299c49a693b20654e6