### PR TITLE
Add environment variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,33 @@ obtain a transcript using Yandex Cloud SpeechKit.
 - `database/queries.py` – helper functions for common database operations.
 - `main.py` – glue code tying everything together.
 
-Environment variables are used for credentials.
+## Environment variables
+
+### Telegram
+
+- `TELEGRAM_BOT_TOKEN` – token used to authenticate the bot.
+
+### MySQL
+
+- `MYSQL_USER`
+- `MYSQL_PASSWORD`
+- `MYSQL_HOST`
+- `MYSQL_PORT`
+- `MYSQL_DB`
+
+### Yandex Cloud
+
+#### S3
+
+- `YC_ACCESS_KEY_ID`
+- `YC_SECRET_ACCESS_KEY`
+- `S3_ENDPOINT`
+- `S3_BUCKET`
+
+#### SpeechKit
+
+- `YC_IAM_TOKEN`
+- `YC_FOLDER_ID`
 
 ## Database schema
 

--- a/database/connection.py
+++ b/database/connection.py
@@ -11,6 +11,11 @@ MYSQL_HOST = os.getenv("MYSQL_HOST")
 MYSQL_PORT = os.getenv("MYSQL_PORT")
 MYSQL_DB = os.getenv("MYSQL_DB")
 
+if not all([MYSQL_USER, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_PORT, MYSQL_DB]):
+    raise RuntimeError(
+        "MYSQL_USER, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_PORT and MYSQL_DB must be set"
+    )
+
 # Как можно скачать сертификат для подключения к MySQL
 # mkdir ~/.mysql
 # curl -o ~/.mysql/root.crt https://storage.yandexcloud.net/cloud-certs/CA.pem

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -7,16 +7,24 @@ from typing import Optional
 
 import boto3
 
+YC_ACCESS_KEY_ID = os.environ.get("YC_ACCESS_KEY_ID")
+YC_SECRET_ACCESS_KEY = os.environ.get("YC_SECRET_ACCESS_KEY")
+S3_ENDPOINT = os.environ.get("S3_ENDPOINT")
+S3_BUCKET = os.environ.get("S3_BUCKET")
 
-def upload_file(file_path: str | Path, bucket: str, object_name: Optional[str] = None) -> str:
-    """Upload *file_path* to *bucket* in Yandex Cloud S3.
+if not all([YC_ACCESS_KEY_ID, YC_SECRET_ACCESS_KEY, S3_ENDPOINT, S3_BUCKET]):
+    raise RuntimeError(
+        "YC_ACCESS_KEY_ID, YC_SECRET_ACCESS_KEY, S3_ENDPOINT and S3_BUCKET must be set"
+    )
+
+
+def upload_file(file_path: str | Path, object_name: Optional[str] = None) -> str:
+    """Upload *file_path* to Yandex Cloud S3.
 
     Parameters
     ----------
     file_path:
         Local path to the file to upload.
-    bucket:
-        Name of the destination S3 bucket.
     object_name:
         Name of the object in the bucket. Defaults to the file name.
 
@@ -30,9 +38,9 @@ def upload_file(file_path: str | Path, bucket: str, object_name: Optional[str] =
         object_name = file_path.name
 
     session = boto3.session.Session(
-        aws_access_key_id=os.environ.get("YC_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.environ.get("YC_SECRET_ACCESS_KEY"),
+        aws_access_key_id=YC_ACCESS_KEY_ID,
+        aws_secret_access_key=YC_SECRET_ACCESS_KEY,
     )
-    s3 = session.client("s3", endpoint_url=os.environ.get("YC_S3_ENDPOINT"))
-    s3.upload_file(str(file_path), bucket, object_name)
-    return f"s3://{bucket}/{object_name}"
+    s3 = session.client("s3", endpoint_url=S3_ENDPOINT)
+    s3.upload_file(str(file_path), S3_BUCKET, object_name)
+    return f"s3://{S3_BUCKET}/{object_name}"


### PR DESCRIPTION
## Summary
- ensure Telegram token is defined before starting the bot
- centralize S3 bucket configuration and validation in s3 helper
- validate S3 and SpeechKit credentials and endpoint at import time
- check MySQL connection settings for completeness
- rename YC_S3_ENDPOINT to S3_ENDPOINT
- document required environment variables in README

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68978cc9734c832983359326b347e75c