### PR TITLE
Use API key for SpeechKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ obtain a transcript using Yandex Cloud SpeechKit.
 
 #### S3
 
-- `YC_ACCESS_KEY_ID`
-- `YC_SECRET_ACCESS_KEY`
+- `S3_ACCESS_KEY`
+- `S3_SECRET_KEY`
 - `S3_ENDPOINT`
 - `S3_BUCKET`
 
 #### SpeechKit
 
-- `YC_IAM_TOKEN`
+- `YC_API_KEY`
 - `YC_FOLDER_ID`
 
 ## Database schema

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -7,14 +7,14 @@ from typing import Optional
 
 import boto3
 
-YC_ACCESS_KEY_ID = os.environ.get("YC_ACCESS_KEY_ID")
-YC_SECRET_ACCESS_KEY = os.environ.get("YC_SECRET_ACCESS_KEY")
+S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY")
+S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY")
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT")
 S3_BUCKET = os.environ.get("S3_BUCKET")
 
-if not all([YC_ACCESS_KEY_ID, YC_SECRET_ACCESS_KEY, S3_ENDPOINT, S3_BUCKET]):
+if not all([S3_ACCESS_KEY, S3_SECRET_KEY, S3_ENDPOINT, S3_BUCKET]):
     raise RuntimeError(
-        "YC_ACCESS_KEY_ID, YC_SECRET_ACCESS_KEY, S3_ENDPOINT and S3_BUCKET must be set"
+        "S3_ACCESS_KEY, S3_SECRET_KEY, S3_ENDPOINT and S3_BUCKET must be set"
     )
 
 
@@ -38,8 +38,8 @@ def upload_file(file_path: str | Path, object_name: Optional[str] = None) -> str
         object_name = file_path.name
 
     session = boto3.session.Session(
-        aws_access_key_id=YC_ACCESS_KEY_ID,
-        aws_secret_access_key=YC_SECRET_ACCESS_KEY,
+        aws_access_key_id=S3_ACCESS_KEY,
+        aws_secret_access_key=S3_SECRET_KEY,
     )
     s3 = session.client("s3", endpoint_url=S3_ENDPOINT)
     s3.upload_file(str(file_path), S3_BUCKET, object_name)

--- a/utils/speechkit.py
+++ b/utils/speechkit.py
@@ -9,15 +9,15 @@ import requests
 API_URL = "https://transcribe.api.cloud.yandex.net/speech/stt/v2/longRunningRecognize"
 OPERATIONS_URL = "https://operation.api.cloud.yandex.net/operations/{id}"
 
-YC_IAM_TOKEN = os.environ.get("YC_IAM_TOKEN")
+YC_API_KEY = os.environ.get("YC_API_KEY")
 YC_FOLDER_ID = os.environ.get("YC_FOLDER_ID")
 
-if not YC_IAM_TOKEN or not YC_FOLDER_ID:
-    raise RuntimeError("YC_IAM_TOKEN and YC_FOLDER_ID must be set")
+if not YC_API_KEY or not YC_FOLDER_ID:
+    raise RuntimeError("YC_API_KEY and YC_FOLDER_ID must be set")
 
 
 def _auth_headers() -> Dict[str, str]:
-    return {"Authorization": f"Bearer {YC_IAM_TOKEN}"}
+    return {"Authorization": f"Api-Key {YC_API_KEY}"}
 
 
 def get_transcription(operation_id: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- switch SpeechKit auth from IAM token to API key
- document YC_API_KEY environment variable in README
- rename S3 auth environment variables to S3_ACCESS_KEY and S3_SECRET_KEY

## Testing
- `python -m py_compile utils/s3.py`
- `python -m py_compile utils/speechkit.py`


------
https://chatgpt.com/codex/tasks/task_e_689796f79bcc8329bb0684b2ac7c888a