### PR TITLE
Name transcription files after source

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -32,7 +32,8 @@ async def check_running_tasks(context: ContextTypes.DEFAULT_TYPE) -> None:
 
         text = parse_text(result)
 
-        path = Path(f"transcription_{task.id}.txt")
+        source_stem = Path(task.audio_s3_path).stem
+        path = Path(f"{source_stem}.txt")
         path.write_text(text, encoding="utf-8")
 
         object_name = f"result/{task.telegram_id}/{path.name}"


### PR DESCRIPTION
## Summary
- name transcription results after the source audio file instead of task id

## Testing
- `python -m py_compile scheduler.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897cf291ee883298a086f95e0456fc0