### PR TITLE
Send early transcription info to user

### DIFF
--- a/utils/ffmpeg.py
+++ b/utils/ffmpeg.py
@@ -3,6 +3,40 @@ import subprocess
 from pathlib import Path
 
 
+def get_media_duration(source: str | Path) -> float:
+    """Return duration of the media file in seconds.
+
+    The function relies on ``ffprobe`` being available in the system PATH.
+
+    Parameters
+    ----------
+    source:
+        Path to the input audio or video file.
+
+    Returns
+    -------
+    float
+        Duration in seconds. Returns ``0.0`` if the duration could not be
+        determined.
+    """
+    src = Path(source)
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(src),
+    ]
+    try:
+        out = subprocess.check_output(command, text=True).strip()
+        return float(out)
+    except Exception:
+        return 0.0
+
+
 def convert_to_ogg(source: str | Path, destination: str | Path) -> Path:
     """Convert an audio or video file to OGG using ffmpeg.
 


### PR DESCRIPTION
## Summary
- Notify user immediately that a supported file was received and transcription is starting
- Send media duration and Yandex SpeechKit cost after download, before conversion

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6897cfab9c1c8329808e03a7e3257a4c