### PR TITLE
Add transcription confirmation step

### DIFF
--- a/database/queries.py
+++ b/database/queries.py
@@ -45,6 +45,12 @@ def add_transcription(
         return history
 
 
+def get_transcription(transcription_id: int) -> Optional[TranscriptionHistory]:
+    """Fetch a transcription history record by its identifier."""
+    with SessionLocal() as session:
+        return session.get(TranscriptionHistory, transcription_id)
+
+
 def update_transcription(transcription_id: int, **fields: Any) -> Optional[TranscriptionHistory]:
     """Update fields of an existing transcription history record."""
     if not fields:


### PR DESCRIPTION
## Summary
- Clarify initial media acknowledgment and remove unused file_id
- Add "Распознать" and "Отменить" buttons with removal after use
- Support cancelling pending transcription tasks
- Send file received message only after confirming the media type is supported

## Testing
- `python -m py_compile main.py utils/*.py scheduler.py database/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898558ab4a88329971aee3c037f7e59