### PR TITLE
Add balance tracking and payments for transcription tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ obtain a transcript using Yandex Cloud SpeechKit.
 CREATE TABLE IF NOT EXISTS users (
     telegram_id BIGINT PRIMARY KEY,
     telegram_login VARCHAR(32),
-    balance DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    balance DECIMAL(10,2) NOT NULL DEFAULT 250.00,
     registered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/database/models.py
+++ b/database/models.py
@@ -30,7 +30,7 @@ class User(Base):
     telegram_login = Column(String(32), nullable=True)
 
     # Account balance
-    balance = Column(Numeric(10, 2), nullable=False, default=0.00)
+    balance = Column(Numeric(10, 2), nullable=False, default=250.00)
 
     # Registration timestamp
     registered_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())

--- a/database/queries.py
+++ b/database/queries.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Optional, Any
+from decimal import Decimal
 
 from .connection import SessionLocal
 from .models import User, TranscriptionHistory
@@ -74,3 +75,15 @@ def get_transcriptions_by_status(status: str) -> list[TranscriptionHistory]:
             .filter(TranscriptionHistory.status == status)
             .all()
         )
+
+
+def change_user_balance(telegram_id: int, delta: Decimal) -> Optional[User]:
+    """Add *delta* to user's balance and return updated user."""
+    with SessionLocal() as session:
+        user = session.get(User, telegram_id)
+        if user is None:
+            return None
+        user.balance = (user.balance or Decimal("0")) + delta
+        session.commit()
+        session.refresh(user)
+        return user

--- a/utils/speechkit.py
+++ b/utils/speechkit.py
@@ -5,6 +5,7 @@ import requests
 from typing import Dict, Any, Optional
 from typing import Optional
 from math import ceil
+from decimal import Decimal
 
 
 API_URL = "https://transcribe.api.cloud.yandex.net/speech/stt/v2/longRunningRecognize"
@@ -122,3 +123,14 @@ def cost_yc_async_rub(duration_s: float, channels: int = 1, deferred: bool = Fal
 
     cost_rub = blocks_15s * (0.0375 if deferred else 0.15)
     return f"{cost_rub:.2f}"
+
+
+def available_time_by_balance(
+    balance_rub: Decimal, channels: int = 1, deferred: bool = False
+) -> tuple[int, int]:
+    """Return minutes and seconds that can be transcribed for *balance_rub*."""
+    price_per_block = Decimal("0.0375") if deferred else Decimal("0.15")
+    blocks = int(balance_rub / price_per_block)
+    total_seconds = blocks * 15
+    minutes, seconds = divmod(int(total_seconds), 60)
+    return minutes, seconds


### PR DESCRIPTION
## Summary
- set default user balance to 250₽
- show available balance and transcribable time
- verify funds before processing files and charge on task start
- centralize balance-based time calculation
- display current balance and required cost when funds are insufficient

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68987bb6d2848329ab2d220bd420dd02