### PR TITLE
Store transcription cost in history

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS transcription_history (
     status VARCHAR(32) NOT NULL,
     audio_s3_path TEXT NOT NULL,
     duration_seconds INTEGER,
+    price_rub DECIMAL(10,2),
     result_s3_path TEXT,
     result_json TEXT,
     operation_id VARCHAR(128),

--- a/database/models.py
+++ b/database/models.py
@@ -63,6 +63,9 @@ class TranscriptionHistory(Base):
     # Duration of the audio in seconds
     duration_seconds = Column(Integer, nullable=True)
 
+    # Cost of recognition in rubles
+    price_rub = Column(Numeric(10, 2), nullable=True)
+
     # Path to the transcription result in S3
     result_s3_path = Column(Text, nullable=True)
 

--- a/database/queries.py
+++ b/database/queries.py
@@ -29,6 +29,7 @@ def add_transcription(
     status: str,
     audio_s3_path: str,
     duration_seconds: int | None = None,
+    price_rub: Decimal | None = None,
     result_s3_path: str | None = None,
 ) -> TranscriptionHistory:
     """Persist a new transcription history record."""
@@ -38,6 +39,7 @@ def add_transcription(
             status=status,
             audio_s3_path=audio_s3_path,
             duration_seconds=duration_seconds,
+            price_rub=price_rub,
             result_s3_path=result_s3_path,
         )
         session.add(history)

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ async def handle_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         status="pending",
         audio_s3_path=s3_uri,
         duration_seconds=int(duration),
+        price_rub=price_dec,
         result_s3_path=None,
     )
 
@@ -163,7 +164,7 @@ async def handle_create_task(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if user is None:
         await query.edit_message_text("Пользователь не найден")
         return
-    price = Decimal(cost_yc_async_rub(task.duration_seconds or 0))
+    price = Decimal(task.price_rub or 0)
     if user.balance < price:
         await query.edit_message_text(
             f"Недостаточно средств. Баланс: {user.balance} ₽, требуется: {price} ₽"


### PR DESCRIPTION
## Summary
- track recognition price in `transcription_history`
- persist price in add_transcription and reuse in task creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689889a8e2c08329a03843d4844d8a70