### PR TITLE
Add history command to show recent transcriptions

### DIFF
--- a/database/queries.py
+++ b/database/queries.py
@@ -79,6 +79,18 @@ def get_transcriptions_by_status(status: str) -> list[TranscriptionHistory]:
         )
 
 
+def get_recent_transcriptions(telegram_id: int, limit: int = 10) -> list[TranscriptionHistory]:
+    """Return recent transcriptions for *telegram_id* limited by *limit*."""
+    with SessionLocal() as session:
+        return (
+            session.query(TranscriptionHistory)
+            .filter(TranscriptionHistory.telegram_id == telegram_id)
+            .order_by(TranscriptionHistory.id.desc())
+            .limit(limit)
+            .all()
+        )
+
+
 def change_user_balance(telegram_id: int, delta: Decimal) -> Optional[User]:
     """Add *delta* to user's balance and return updated user."""
     with SessionLocal() as session:

--- a/utils/tg.py
+++ b/utils/tg.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+STATUS_EMOJI = {
+    "pending": "🕓",
+    "running": "⏳",
+    "done": "✅",
+    "failed": "❌",
+    "cancelled": "🚫",
+}
+
+
+def fmt_duration(seconds: int | None) -> str:
+    """Format *seconds* to H:MM:SS or M:SS."""
+    if not seconds and seconds != 0:
+        return "—"
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:d}:{m:02d}:{s:02d}" if h else f"{m:d}:{s:02d}"
+
+
+def fmt_price(value) -> str:
+    """Format price value in rubles."""
+    if value is None:
+        return "—"
+    if isinstance(value, Decimal):
+        return f"{value:.2f} ₽"
+    return f"{float(value):.2f} ₽"


### PR DESCRIPTION
## Summary
- add `/history` command listing last transcriptions with status, duration, price and Moscow time
- factor out Telegram formatting helpers to `utils/tg.py`
- add database helper to fetch recent transcription records

## Testing
- `python -m py_compile main.py database/queries.py utils/tg.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689893948ae88329a5ac05710fa43c7f