### PR TITLE
feat: support local bot api server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ obtain a transcript using Yandex Cloud SpeechKit.
 ### Telegram
 
 - `TELEGRAM_BOT_TOKEN` – token used to authenticate the bot.
-- `LOCAL_PTB` – set to any value to use a local Bot API server running at
-  `http://127.0.0.1:8081`.
+- `TELEGRAM_API_ID` – optional, required only when using a local Bot API server.
+- `TELEGRAM_API_HASH` – optional, required only when using a local Bot API server.
+- `USE_LOCAL_PTB` – set to any value to use a local Bot API server running at
+  `http://127.0.0.1:8081`. You need to run the Bot API server locally (see
+  below).
 
 ### MySQL
 
@@ -42,6 +45,26 @@ obtain a transcript using Yandex Cloud SpeechKit.
 
 - `YC_API_KEY`
 - `YC_FOLDER_ID`
+
+## Local Bot API server
+
+To handle large files you can run a local copy of Telegram's Bot API server.
+Example using Docker:
+
+```bash
+docker run -d --name tg-bot-api \
+  -p 8081:8081 \
+  -v /var/lib/telegram-bot-api:/var/lib/telegram-bot-api \
+  -e TELEGRAM_API_ID=$TELEGRAM_API_ID \
+  -e TELEGRAM_API_HASH=$TELEGRAM_API_HASH \
+  -e TELEGRAM_LOCAL=True \
+  aiogram/telegram-bot-api:latest \
+  --http-ip-address=0.0.0.0 \
+  --dir=/var/lib/telegram-bot-api
+```
+
+Run this container and set `USE_LOCAL_PTB` so that the bot uses the local
+server.
 
 ## Database schema
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Telegram bot for ClearTranscriptBot."""
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -33,7 +34,7 @@ from zoneinfo import ZoneInfo
 from datetime import timezone
 
 TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
-USE_LOCAL_PTB = os.environ.get("LOCAL_PTB") is not None
+USE_LOCAL_PTB = os.environ.get("USE_LOCAL_PTB") is not None
 
 if not TELEGRAM_BOT_TOKEN:
     raise RuntimeError("TELEGRAM_BOT_TOKEN must be set")
@@ -132,7 +133,10 @@ async def handle_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         out_dir.mkdir()
 
         local_path = in_dir / Path(file_name).name
-        await file.download_to_drive(custom_path=str(local_path))
+        if USE_LOCAL_PTB:
+            shutil.move(Path(file.file_path), local_path)
+        else:
+            await file.download_to_drive(custom_path=str(local_path))
 
         duration = get_media_duration(local_path)
         price = cost_yc_async_rub(duration)


### PR DESCRIPTION
## Summary
- rename LOCAL_PTB to USE_LOCAL_PTB and handle local paths when downloading files
- document how to run a local Bot API server and how to enable it
- document TELEGRAM_API_ID and TELEGRAM_API_HASH env vars for running a local Bot API server
- move files from local Bot API server instead of copying
- use environment variables in the Docker example for running a local Bot API server

## Testing
- `python -m py_compile main.py utils/*.py database/*.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_6899d4b2820883298bbd9cbdf10bd309