### PR TITLE
feat: move progress updates to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ CREATE TABLE IF NOT EXISTS transcription_history (
     result_s3_path TEXT,
     result_json TEXT,
     operation_id VARCHAR(128),
+    message_id INTEGER,
+    chat_id BIGINT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/database/models.py
+++ b/database/models.py
@@ -72,5 +72,11 @@ class TranscriptionHistory(Base):
     # Identifier of Yandex Cloud operation
     operation_id = Column(String(128), nullable=True)
 
+    # Identifier of the Telegram message with task status
+    message_id = Column(Integer, nullable=True)
+
+    # Telegram chat where the status message was sent
+    chat_id = Column(BigInteger, nullable=True)
+
     # Timestamp when the request was created
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())

--- a/handlers/create_task.py
+++ b/handlers/create_task.py
@@ -1,5 +1,3 @@
-import asyncio
-import time
 from decimal import Decimal
 
 from telegram import Update
@@ -50,50 +48,16 @@ async def handle_create_task(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
     await query.edit_message_reply_markup(reply_markup=None)
 
-    start_time = time.monotonic()
     duration_str = format_duration(0)
     status_message = await query.message.reply_text(
-        f"🧠 Задача №{task_id} в работе\n\n"
-        f"Прошло времени: {duration_str}\n\n"
-        "Отправлю результат, как только всё будет готово."
+        f"🧠 Задача №{task_id} в работе\n\n",
+        f"Прошло времени: {duration_str}\n\n",
+        "Отправлю результат, как только всё будет готово.",
     )
 
-    async def progress_updater() -> None:
-        while True:
-            await asyncio.sleep(5)
-            updated_task = get_transcription(task_id)
-            if updated_task.status == "running":
-                duration = int(time.monotonic() - start_time)
-                duration_text = format_duration(duration)
-                try:
-                    await status_message.edit_text(
-                        f"🧠 Задача №{task_id} в работе\n\n"
-                        f"Прошло времени: {duration_text}\n\n"
-                        "Отправлю результат, как только всё будет готово."
-                    )
-                except Exception:
-                    pass
-                continue
-            if updated_task.status == "completed":
-                duration = int(time.monotonic() - start_time)
-                duration_text = format_duration(duration)
-                try:
-                    await status_message.edit_text(
-                        f"✅ Задача №{task_id} готова!\n\n"
-                        f"Прошло времени: {duration_text}\n\n"
-                        "Отправляю результат…"
-                    )
-                except Exception:
-                    pass
-                break
-            if updated_task.status == "failed":
-                try:
-                    await status_message.edit_text(
-                        f"❌ Задача №{task_id} завершилась с ошибкой. Попробуйте ещё раз."
-                    )
-                except Exception:
-                    pass
-                break
-            break
+    update_transcription(
+        task.id,
+        message_id=status_message.message_id,
+        chat_id=status_message.chat_id,
+    )
 
-    context.application.create_task(progress_updater())

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,21 +1,43 @@
 """Periodic scheduler for checking transcription statuses."""
 from pathlib import Path
+from datetime import datetime
 
 from telegram.ext import ContextTypes
 
 from database.queries import get_transcriptions_by_status, update_transcription
-from utils.speechkit import fetch_transcription_result, parse_text
+from utils.speechkit import fetch_transcription_result, parse_text, format_duration
 from utils.s3 import upload_file
 
 
 async def check_running_tasks(context: ContextTypes.DEFAULT_TYPE) -> None:
     """Poll running transcriptions and send results when ready."""
     bot = context.bot
+    now = datetime.utcnow()
     tasks = get_transcriptions_by_status("running")
     for task in tasks:
         if not task.operation_id:
             print(f"Task {task.id} doesn't have operation_id")
             continue
+
+        duration = int((now - task.created_at).total_seconds())
+        if (
+            duration > 0
+            and duration % 5 == 0
+            and task.chat_id
+            and task.message_id
+        ):
+            try:
+                await bot.edit_message_text(
+                    chat_id=task.chat_id,
+                    message_id=task.message_id,
+                    text=(
+                        f"🧠 Задача №{task.id} в работе\n\n"
+                        f"Прошло времени: {format_duration(duration)}\n\n"
+                        "Отправлю результат, как только всё будет готово."
+                    ),
+                )
+            except Exception:
+                pass
 
         result = fetch_transcription_result(task.operation_id)
 
@@ -26,8 +48,18 @@ async def check_running_tasks(context: ContextTypes.DEFAULT_TYPE) -> None:
         update_transcription(task.id, result_json=result)
 
         if "response" not in result:
-            error = result.get("error", "Unknown error")
             update_transcription(task.id, status="failed")
+            if task.chat_id and task.message_id:
+                try:
+                    await bot.edit_message_text(
+                        chat_id=task.chat_id,
+                        message_id=task.message_id,
+                        text=(
+                            f"❌ Задача №{task.id} завершилась с ошибкой. Попробуйте ещё раз."
+                        ),
+                    )
+                except Exception:
+                    pass
             continue
 
         text = parse_text(result)
@@ -39,11 +71,38 @@ async def check_running_tasks(context: ContextTypes.DEFAULT_TYPE) -> None:
         object_name = f"result/{task.telegram_id}/{path.name}"
         s3_uri = upload_file(path, object_name)
 
+        duration = int((datetime.utcnow() - task.created_at).total_seconds())
+        duration_text = format_duration(duration)
+        if task.chat_id and task.message_id:
+            try:
+                await bot.edit_message_text(
+                    chat_id=task.chat_id,
+                    message_id=task.message_id,
+                    text=(
+                        f"✅ Задача №{task.id} готова!\n\n"
+                        f"Прошло времени: {duration_text}\n\n"
+                        "Отправляю результат…"
+                    ),
+                )
+            except Exception:
+                pass
+
         try:
             await bot.send_document(chat_id=task.telegram_id, document=path.open("rb"))
             update_transcription(task.id, status="completed", result_s3_path=s3_uri)
-        except Exception as e:
+        except Exception:
             print("Ошибка во время отправки результата")
             update_transcription(task.id, status="failed", result_s3_path=s3_uri)
+            if task.chat_id and task.message_id:
+                try:
+                    await bot.edit_message_text(
+                        chat_id=task.chat_id,
+                        message_id=task.message_id,
+                        text=(
+                            f"❌ Задача №{task.id} завершилась с ошибкой. Попробуйте ещё раз."
+                        ),
+                    )
+                except Exception:
+                    pass
         finally:
             path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- store status message identifiers for each transcription
- drive progress and completion updates from scheduler
- throttle progress message updates to 5-second intervals

## Testing
- `python -m py_compile database/models.py handlers/create_task.py scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_689a1eba62fc8329b0853df119cecce6