### PR TITLE
Add 4-hour media duration limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Telegram bot for automatic audio/video transcription:
 
 ## Features
 
-- 🎙 Supports audio and video files
-- ⏱️ Handles media up to 4 hours (SpeechKit limit)
+- 🎙 Supports audio and video files (up to 4 hours)
 - 📦 Stores files in Yandex Cloud S3
 - 💬 Transcription via Yandex SpeechKit
 - 💰 Balance and billing inside Telegram

--- a/handlers/file.py
+++ b/handlers/file.py
@@ -86,9 +86,12 @@ async def handle_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                 "Возможно, формат не поддерживается или файл повреждён"
             )
             return
+
+        duration_str = format_duration(int(duration))
         if duration > MAX_AUDIO_DURATION:
             await message.reply_text(
-                "Файл слишком длинный. Поддерживаются записи до 4 часов"
+                "Файл слишком длинный: {duration_str}\n"
+                "Максимально допустимая длительность — 4 часа"
             )
             return
 
@@ -134,7 +137,6 @@ async def handle_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         ),
     ]
 
-    duration_str = format_duration(int(duration))
     await message.reply_text(
         f"Длительность: {duration_str}\nСтоимость: {price} ₽",
         reply_markup=InlineKeyboardMarkup([buttons]),

--- a/utils/speechkit.py
+++ b/utils/speechkit.py
@@ -7,9 +7,9 @@ from decimal import Decimal
 from typing import Dict, Optional
 
 
-
 API_URL = "https://transcribe.api.cloud.yandex.net/speech/stt/v2/longRunningRecognize"
 OPERATIONS_URL = "https://operation.api.cloud.yandex.net/operations/{id}"
+
 MAX_AUDIO_DURATION = 4 * 60 * 60  # seconds, SpeechKit limit
 
 YC_API_KEY = os.environ.get("YC_API_KEY")


### PR DESCRIPTION
## Summary
- enforce Yandex SpeechKit's 4‑hour limit on uploaded audio/video
- document 4‑hour media limit in README

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68b80c86e49c83299cb096da42eed5f7